### PR TITLE
Minion calculator page

### DIFF
--- a/api/ApiHelper.tsx
+++ b/api/ApiHelper.tsx
@@ -1427,6 +1427,36 @@ export function initAPI(returnSSRResponse: boolean = false): API {
         })
     }
 
+    let getBestMinions = (options: MinionRankingOptions): Promise<MinionRankingResponse> => {
+        let query = new URLSearchParams({
+            offlineHours: options.offlineHours.toString(),
+            sell: options.sell,
+            buy: options.buy,
+            objective: options.objective,
+            speedBoost: options.speedBoost.toString(),
+            hopper: options.hopper,
+            compaction: options.compaction.toString(),
+            derpy: options.derpy.toString(),
+            limit: options.limit.toString()
+        })
+        if (options.budget !== undefined) {
+            query.set('budget', options.budget.toString())
+        }
+
+        return new Promise((resolve, reject) => {
+            httpApi.sendApiRequest({
+                type: RequestType.GET_BEST_MINIONS,
+                customRequestURL: `${getApiEndpoint()}/${RequestType.GET_BEST_MINIONS}?${query.toString()}`,
+                data: '',
+                resolve,
+                reject: function (error) {
+                    apiErrorHandler(RequestType.GET_BEST_MINIONS, error, options)
+                    reject(error)
+                }
+            })
+        })
+    }
+
     let triggerPlayerNameCheck = (playerUUID: string): Promise<void> => {
         return postApiPlayerPlayerUuidName(playerUUID)
             .then(() => {})
@@ -2271,6 +2301,7 @@ export function initAPI(returnSSRResponse: boolean = false): API {
         playerSearch,
         getProfitableCrafts,
         getCraftAcquisitionPlan,
+        getBestMinions,
         getLowSupplyItems,
         sendFeedback,
         triggerPlayerNameCheck,

--- a/api/ApiTypes.d.tsx
+++ b/api/ApiTypes.d.tsx
@@ -51,6 +51,7 @@ export enum RequestType {
     PLAYER_SEARCH = 'search/player',
     GET_PROFITABLE_CRAFTS = 'craft/profit',
     GET_CRAFT_ACQUISITION = 'craft/acquisition',
+    GET_BEST_MINIONS = 'minions/best',
     GET_LOW_SUPPLY_ITEMS = 'auctions/supply/low',
     SEND_FEEDBACK = 'sendFeedback',
     TRIGGER_PLAYER_NAME_CHECK = 'triggerNameCheck',

--- a/app/minions/page.tsx
+++ b/app/minions/page.tsx
@@ -1,0 +1,78 @@
+import { Container } from 'react-bootstrap'
+import { initAPI } from '../../api/ApiHelper'
+import { BottomBanner } from '../../components/BottomBanner/BottomBanner'
+import { MinionCalculator } from '../../components/MinionCalculator/MinionCalculator'
+import Search from '../../components/Search/Search'
+import { ToolLandingSeo } from '../../components/Seo/ToolLandingSeo'
+import { toolLandingSeoContent } from '../../components/Seo/toolLandingSeoContent'
+import { getCanonicalUrl, getHeadMetadata } from '../../utils/SSRUtils'
+
+const seoContent = toolLandingSeoContent.minions
+
+const defaults: MinionRankingOptions = {
+    offlineHours: 24,
+    sell: 'offer',
+    buy: 'instant',
+    objective: 'coins',
+    speedBoost: 0,
+    hopper: 'none',
+    compaction: true,
+    derpy: false,
+    limit: 10
+}
+
+type MinionSearchParams = Partial<Record<keyof MinionRankingOptions, string | string[]>>
+
+function first(value?: string | string[]) {
+    return Array.isArray(value) ? value[0] : value
+}
+
+function numberParam(value: string | undefined, fallback: number, minimum = 0) {
+    const parsed = Number(value)
+    return Number.isFinite(parsed) && parsed >= minimum ? parsed : fallback
+}
+
+function enumParam<T extends string>(value: string | undefined, values: readonly T[], fallback: T): T {
+    return values.includes(value as T) ? (value as T) : fallback
+}
+
+function parseOptions(params: MinionSearchParams): MinionRankingOptions {
+    const budgetValue = first(params.budget)
+    const budget = budgetValue ? numberParam(budgetValue, 0) : undefined
+
+    return {
+        offlineHours: numberParam(first(params.offlineHours), defaults.offlineHours, 1),
+        budget,
+        sell: enumParam(first(params.sell), ['offer', 'instant', 'npc'] as const, defaults.sell),
+        buy: enumParam(first(params.buy), ['instant', 'order'] as const, defaults.buy),
+        objective: enumParam(first(params.objective), ['coins', 'experience'] as const, defaults.objective),
+        speedBoost: numberParam(first(params.speedBoost), defaults.speedBoost),
+        hopper: enumParam(first(params.hopper), ['none', 'budget', 'enchanted'] as const, defaults.hopper),
+        compaction: first(params.compaction) !== 'false',
+        derpy: first(params.derpy) === 'true',
+        limit: Math.floor(Math.min(50, numberParam(first(params.limit), defaults.limit, 1)))
+    }
+}
+
+export default async function Page({ searchParams }: { searchParams: Promise<MinionSearchParams> }) {
+    const options = parseOptions(await searchParams)
+    const ranking = await initAPI(true).getBestMinions(options)
+
+    return (
+        <>
+            <Container>
+                <Search />
+                <h1>Hypixel SkyBlock Minion Calculator</h1>
+                <p className="lead">Find the best minion for the time you actually leave it running.</p>
+                <hr />
+                <MinionCalculator initialRanking={ranking} initialOptions={options} />
+                <ToolLandingSeo content={seoContent} />
+            </Container>
+            <BottomBanner />
+        </>
+    )
+}
+
+export const metadata = getHeadMetadata(seoContent.metadataTitle, seoContent.metadataDescription, undefined, undefined, undefined, getCanonicalUrl('/minions'))
+
+export const revalidate = 0

--- a/components/MinionCalculator/MinionCalculator.tsx
+++ b/components/MinionCalculator/MinionCalculator.tsx
@@ -1,0 +1,263 @@
+'use client'
+
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { FormEvent, useState } from 'react'
+import { Alert, Badge, Button, Col, Form, Row, Spinner, Table } from 'react-bootstrap'
+import api from '../../api/ApiHelper'
+
+interface Props {
+    initialRanking: MinionRankingResponse
+    initialOptions: MinionRankingOptions
+}
+
+const presets: { label: string; description: string; options: Partial<MinionRankingOptions> }[] = [
+    { label: 'Collect daily', description: '24 hours', options: { offlineHours: 24, hopper: 'none', derpy: false } },
+    { label: 'Collect every Derpy', description: '124 days', options: { offlineHours: 2976, hopper: 'none', derpy: true } },
+    { label: 'Leave for years', description: '5 years', options: { offlineHours: 43800, hopper: 'enchanted', derpy: false } }
+]
+
+const formatNumber = new Intl.NumberFormat('en-US', { maximumFractionDigits: 1 })
+
+function toSearchParams(options: MinionRankingOptions) {
+    const params = new URLSearchParams()
+    Object.entries(options).forEach(([key, value]) => {
+        if (value !== undefined && value !== '') params.set(key, String(value))
+    })
+    return params
+}
+
+export function MinionCalculator({ initialRanking, initialOptions }: Props) {
+    const router = useRouter()
+    const [options, setOptions] = useState(initialOptions)
+    const [offlineHoursInput, setOfflineHoursInput] = useState(String(initialOptions.offlineHours))
+    const [budgetInput, setBudgetInput] = useState(initialOptions.budget === undefined ? '' : String(initialOptions.budget))
+    const [speedBoostInput, setSpeedBoostInput] = useState(String(initialOptions.speedBoost * 100))
+    const [limitInput, setLimitInput] = useState(String(initialOptions.limit))
+    const [ranking, setRanking] = useState(initialRanking)
+    const [loading, setLoading] = useState(false)
+    const [error, setError] = useState(false)
+
+    async function calculate(nextOptions: MinionRankingOptions) {
+        nextOptions = {
+            ...nextOptions,
+            offlineHours: Math.max(1, nextOptions.offlineHours || 1),
+            speedBoost: Math.max(0, nextOptions.speedBoost || 0),
+            limit: Math.min(50, Math.max(1, nextOptions.limit || 1))
+        }
+        setOptions(nextOptions)
+        setOfflineHoursInput(String(nextOptions.offlineHours))
+        setBudgetInput(nextOptions.budget === undefined ? '' : String(nextOptions.budget))
+        setSpeedBoostInput(String(nextOptions.speedBoost * 100))
+        setLimitInput(String(nextOptions.limit))
+        setLoading(true)
+        setError(false)
+        router.replace(`/minions?${toSearchParams(nextOptions).toString()}`, { scroll: false })
+
+        try {
+            const nextRanking = await api.getBestMinions(nextOptions)
+            setRanking(nextRanking)
+        } catch {
+            setRanking({ minions: [], generatedAt: '' })
+            setError(true)
+        } finally {
+            setLoading(false)
+        }
+    }
+
+    function submit(event: FormEvent) {
+        event.preventDefault()
+        calculate({
+            ...options,
+            offlineHours: Number(offlineHoursInput),
+            budget: budgetInput === '' ? undefined : Number(budgetInput),
+            speedBoost: Number(speedBoostInput) / 100,
+            limit: Number(limitInput)
+        })
+    }
+
+    const rows = ranking.minions ?? []
+
+    return (
+        <section aria-label="Minion calculator">
+            <div className="mb-3">
+                <h2 className="h4">Start with your collection plan</h2>
+                <div className="d-flex flex-wrap gap-2">
+                    {presets.map(preset => (
+                        <Button key={preset.label} variant="outline-primary" onClick={() => calculate({ ...options, ...preset.options })} disabled={loading}>
+                            {preset.label} <small className="d-block">{preset.description}</small>
+                        </Button>
+                    ))}
+                </div>
+            </div>
+
+            <Form onSubmit={submit} className="border rounded p-3 mb-4">
+                <Row className="g-3">
+                    <Col md={4} lg={3}>
+                        <Form.Label htmlFor="offlineHours">Hours between collections</Form.Label>
+                        <Form.Control
+                            id="offlineHours"
+                            type="number"
+                            min={1}
+                            step="any"
+                            value={offlineHoursInput}
+                            onChange={event => setOfflineHoursInput(event.target.value)}
+                        />
+                    </Col>
+                    <Col md={4} lg={3}>
+                        <Form.Label htmlFor="budget">Setup budget (optional)</Form.Label>
+                        <Form.Control
+                            id="budget"
+                            type="number"
+                            min={0}
+                            placeholder="No limit"
+                            value={budgetInput}
+                            onChange={event => setBudgetInput(event.target.value)}
+                        />
+                    </Col>
+                    <Col md={4} lg={3}>
+                        <Form.Label htmlFor="objective">Rank by</Form.Label>
+                        <Form.Select
+                            id="objective"
+                            value={options.objective}
+                            onChange={event => setOptions({ ...options, objective: event.target.value as MinionRankingOptions['objective'] })}
+                        >
+                            <option value="coins">Coins per day</option>
+                            <option value="experience">Skill XP per day</option>
+                        </Form.Select>
+                    </Col>
+                    <Col md={4} lg={3}>
+                        <Form.Label htmlFor="speedBoost">Additive speed boost (%)</Form.Label>
+                        <Form.Control
+                            id="speedBoost"
+                            type="number"
+                            min={0}
+                            step="any"
+                            value={speedBoostInput}
+                            onChange={event => setSpeedBoostInput(event.target.value)}
+                        />
+                    </Col>
+                    <Col md={4} lg={3}>
+                        <Form.Label htmlFor="buy">Buy ingredients with</Form.Label>
+                        <Form.Select
+                            id="buy"
+                            value={options.buy}
+                            onChange={event => setOptions({ ...options, buy: event.target.value as MinionRankingOptions['buy'] })}
+                        >
+                            <option value="instant">Instant buys</option>
+                            <option value="order">Buy orders</option>
+                        </Form.Select>
+                    </Col>
+                    <Col md={4} lg={3}>
+                        <Form.Label htmlFor="sell">Sell products with</Form.Label>
+                        <Form.Select
+                            id="sell"
+                            value={options.sell}
+                            onChange={event => setOptions({ ...options, sell: event.target.value as MinionRankingOptions['sell'] })}
+                        >
+                            <option value="offer">Sell offers</option>
+                            <option value="instant">Instant sells</option>
+                            <option value="npc">NPC sales</option>
+                        </Form.Select>
+                    </Col>
+                    <Col md={4} lg={3}>
+                        <Form.Label htmlFor="hopper">Hopper</Form.Label>
+                        <Form.Select
+                            id="hopper"
+                            value={options.hopper}
+                            onChange={event => setOptions({ ...options, hopper: event.target.value as MinionRankingOptions['hopper'] })}
+                        >
+                            <option value="none">None</option>
+                            <option value="budget">Budget Hopper</option>
+                            <option value="enchanted">Enchanted Hopper</option>
+                        </Form.Select>
+                    </Col>
+                    <Col md={4} lg={3}>
+                        <Form.Label htmlFor="limit">Results</Form.Label>
+                        <Form.Control id="limit" type="number" min={1} max={50} value={limitInput} onChange={event => setLimitInput(event.target.value)} />
+                    </Col>
+                    <Col xs={12} className="d-flex flex-wrap gap-4">
+                        <Form.Check
+                            id="compaction"
+                            type="switch"
+                            label="Allow Super Compactor 3000"
+                            checked={options.compaction}
+                            onChange={event => setOptions({ ...options, compaction: event.target.checked })}
+                        />
+                        <Form.Check
+                            id="derpy"
+                            type="switch"
+                            label="Derpy is active"
+                            checked={options.derpy}
+                            onChange={event => setOptions({ ...options, derpy: event.target.checked })}
+                        />
+                    </Col>
+                    <Col xs={12}>
+                        <Button type="submit" disabled={loading}>
+                            {loading ? <Spinner size="sm" aria-label="Calculating" /> : 'Calculate ranking'}
+                        </Button>
+                    </Col>
+                </Row>
+            </Form>
+
+            {error ? <Alert variant="danger">The ranking could not be loaded. Change an input or try again shortly.</Alert> : null}
+            {ranking.generatedAt ? <p className="text-body-secondary">Prices read {new Date(ranking.generatedAt).toLocaleString()}.</p> : null}
+
+            <Table responsive striped hover className="align-middle">
+                <thead>
+                    <tr>
+                        <th scope="col">Rank</th>
+                        <th scope="col">Minion</th>
+                        <th scope="col">Coins/day</th>
+                        <th scope="col">XP/day</th>
+                        <th scope="col">Setup / payback</th>
+                        <th scope="col">Storage</th>
+                        <th scope="col">Products and limits</th>
+                    </tr>
+                </thead>
+                <tbody data-cy="minion-ranking">
+                    {rows.map((minion, index) => (
+                        <tr key={`${minion.name}-${minion.tier}`}>
+                            <td>{index + 1}</td>
+                            <td>
+                                <strong>{minion.name ?? 'Unknown minion'}</strong>
+                                <div>Tier {minion.tier}</div>
+                                <small>{formatNumber.format(minion.secondsBetweenHarvests)} seconds per harvest</small>
+                            </td>
+                            <td>{formatNumber.format(minion.coinsPerDay)}</td>
+                            <td>{formatNumber.format(minion.experiencePerDay)}</td>
+                            <td>
+                                {formatNumber.format(minion.setupCost)} coins
+                                <div>{minion.paybackDays == null ? 'No payback' : `${formatNumber.format(minion.paybackDays)} days`}</div>
+                            </td>
+                            <td>
+                                {formatNumber.format(minion.hoursToFill)} hours
+                                <div>
+                                    <Badge bg={minion.storageLimited ? 'warning' : 'success'} text={minion.storageLimited ? 'dark' : undefined}>
+                                        {minion.storageLimited ? 'Fills before collection' : 'Runs until collection'}
+                                    </Badge>
+                                </div>
+                                <small>{minion.compacted ? 'Compacted' : 'Not compacted'}</small>
+                            </td>
+                            <td>
+                                {minion.itemPages?.map((itemPage, itemIndex) => (
+                                    <span key={itemPage}>
+                                        {itemIndex ? ', ' : ''}
+                                        <Link href={itemPage}>{minion.productTags?.[itemIndex] ?? 'Price'}</Link>
+                                    </span>
+                                ))}
+                                {minion.missingRequirements?.length ? (
+                                    <div className="text-warning-emphasis">Requires: {minion.missingRequirements.join(', ')}</div>
+                                ) : null}
+                                {minion.unpricedIngredients?.length ? (
+                                    <div className="text-warning-emphasis">Unpriced: {minion.unpricedIngredients.join(', ')}</div>
+                                ) : null}
+                            </td>
+                        </tr>
+                    ))}
+                </tbody>
+            </Table>
+            {!loading && !error && rows.length === 0 ? <Alert variant="info">No minions match this setup.</Alert> : null}
+        </section>
+    )
+}

--- a/components/Seo/toolLandingSeoContent.ts
+++ b/components/Seo/toolLandingSeoContent.ts
@@ -25,6 +25,58 @@ export interface ToolLandingSeoContent {
 }
 
 export const toolLandingSeoContent = {
+    minions: {
+        metadataTitle: 'Hypixel SkyBlock Minion Calculator | Best Minions for Coins and XP',
+        metadataDescription:
+            'Compare Hypixel SkyBlock minions by coins per day, XP, setup cost, storage, collection interval, budget, fuel speed, hopper, compaction, and Derpy.',
+        intro: [
+            'The best Hypixel SkyBlock minion depends on when you return. Storage can stop an otherwise excellent setup long before your next collection, so this calculator ranks each minion for your actual offline interval instead of publishing one static list.',
+            'Compare daily collections, a return during Derpy, or years away. Then adjust budget, market order type, speed, hopper, compaction, and whether coins or skill experience matter most.'
+        ],
+        sections: [
+            {
+                title: 'Why the collection interval changes the answer',
+                paragraphs: [
+                    'A fast minion can lead over one day and fall behind over a long absence when its storage fills. The Storage column tells you when production stops, while the storage-limited label explains why a row ranks lower for the selected interval.'
+                ]
+            },
+            {
+                title: 'How to compare minion setups',
+                bullets: [
+                    'Use setup cost and payback time together; daily revenue alone can hide an upgrade that takes too long to recover.',
+                    'Choose the same buy and sell methods you actually use so ingredient costs and output values match your plan.',
+                    'Check missing requirements and unpriced ingredients before treating the displayed setup cost as complete.'
+                ]
+            }
+        ],
+        faqs: [
+            {
+                question: 'Which minion is best to collect once a day?',
+                answer: 'Choose the Daily collection preset. It ranks production over 24 hours and marks any minion whose storage fills before you return.'
+            },
+            {
+                question: 'Why does the best minion change for Derpy or a long absence?',
+                answer: 'Derpy changes output and skill experience, while a longer absence gives limited storage more time to fill. Hoppers and compaction can therefore change the ranking materially.'
+            }
+        ],
+        relatedLinks: [
+            {
+                href: '/bazaar',
+                label: 'Bazaar Prices',
+                description: 'Inspect the live market behind minion output and material values.'
+            },
+            {
+                href: '/crafts',
+                label: 'Craft Flips',
+                description: 'Compare minion income with profitable item crafting.'
+            },
+            {
+                href: '/item/COBBLESTONE',
+                label: 'Cobblestone Price History',
+                description: 'See how a common minion product is priced before committing to a setup.'
+            }
+        ]
+    },
     bazaar: {
         metadataTitle: 'Hypixel SkyBlock Bazaar Flips | Live Spread, Margin and Volume Scanner',
         metadataDescription:

--- a/cypress/e2e/minions.cy.ts
+++ b/cypress/e2e/minions.cy.ts
@@ -1,0 +1,49 @@
+const ranking = (name: string, coinsPerDay: number, storageLimited: boolean) => ({
+    minions: [
+        {
+            name,
+            tier: 11,
+            coinsPerDay,
+            experiencePerDay: 2400,
+            setupCost: 1200000,
+            paybackDays: 4,
+            secondsBetweenHarvests: 30,
+            hoursToFill: storageLimited ? 48 : 1000,
+            storageLimited,
+            compacted: true,
+            missingRequirements: [],
+            unpricedIngredients: [],
+            productTags: ['COBBLESTONE'],
+            itemPages: ['https://sky.coflnet.com/item/COBBLESTONE']
+        }
+    ],
+    generatedAt: '2026-08-24T12:00:00Z'
+})
+
+describe('Minion calculator', () => {
+    it('normalizes a fractional result limit from the URL', () => {
+        cy.visit('/minions?limit=1.5')
+        cy.get('#limit').should('have.value', '1')
+    })
+
+    it('changes the ranking when the collection interval changes', () => {
+        cy.intercept('GET', '**/api/minions/best*', request => {
+            const url = new URL(request.url)
+            const hours = Number(url.searchParams.get('offlineHours'))
+            request.reply(hours === 100 ? ranking('Long Interval Minion', 250000, true) : ranking('Daily Minion', 900000, false))
+        }).as('bestMinions')
+
+        cy.visit('/minions')
+        cy.get('#offlineHours').clear()
+        cy.get('#offlineHours').type('24')
+        cy.contains('button', 'Calculate ranking').click()
+        cy.wait('@bestMinions').its('request.query.offlineHours').should('equal', '24')
+        cy.get('[data-cy="minion-ranking"] tr').first().should('contain.text', 'Daily Minion')
+
+        cy.get('#offlineHours').clear()
+        cy.get('#offlineHours').type('100')
+        cy.contains('button', 'Calculate ranking').click()
+        cy.wait('@bestMinions').its('request.query.offlineHours').should('equal', '100')
+        cy.get('[data-cy="minion-ranking"] tr').first().should('contain.text', 'Long Interval Minion').and('contain.text', 'Fills before collection')
+    })
+})

--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -1,0 +1,6 @@
+{
+    "extends": "../tsconfig.json",
+    "compilerOptions": {
+        "jsx": "react-jsx"
+    }
+}

--- a/global.d.ts
+++ b/global.d.ts
@@ -197,6 +197,41 @@ interface FlipperFilter {
     onlyUnsold?: boolean
 }
 
+interface MinionRankingOptions {
+    offlineHours: number
+    budget?: number
+    sell: 'offer' | 'instant' | 'npc'
+    buy: 'instant' | 'order'
+    objective: 'coins' | 'experience'
+    speedBoost: number
+    hopper: 'none' | 'budget' | 'enchanted'
+    compaction: boolean
+    derpy: boolean
+    limit: number
+}
+
+interface MinionRanking {
+    name?: string
+    tier: number
+    coinsPerDay: number
+    experiencePerDay: number
+    setupCost: number
+    paybackDays?: number | null
+    secondsBetweenHarvests: number
+    hoursToFill: number
+    storageLimited: boolean
+    compacted: boolean
+    missingRequirements?: string[] | null
+    unpricedIngredients?: string[] | null
+    productTags?: string[] | null
+    itemPages?: string[] | null
+}
+
+interface MinionRankingResponse {
+    minions?: MinionRanking[] | null
+    generatedAt: string
+}
+
 interface API {
     search(searchText: string): Promise<SearchResultItem[]>
     trackSearch(fullSearchId: string, fullSearchType: string): void
@@ -264,6 +299,7 @@ interface API {
     sendFeedback(feedbackKey: string, feedback: any): Promise<void>
     getProfitableCrafts(): Promise<ProfitableCraft[]>
     getCraftAcquisitionPlan(itemTag: string, quantity?: number, forceCraft?: boolean): Promise<CraftAcquisitionPlan>
+    getBestMinions(options: MinionRankingOptions): Promise<MinionRankingResponse>
     getLowSupplyItems(): Promise<LowSupplyItem[]>
     sendFeedback(feedbackKey: string, feedback: any): Promise<void>
     triggerPlayerNameCheck(playerUUID: string): Promise<void>

--- a/utils/sitemap-config.ts
+++ b/utils/sitemap-config.ts
@@ -74,6 +74,14 @@ export const SITEMAP_CONFIG = {
             keywords: ['crafting calculator', 'recipe profits', 'crafting guide', 'item crafting']
         },
         {
+            url: '/minions',
+            priority: 0.8,
+            changefreq: 'daily' as const,
+            title: 'Hypixel SkyBlock Minion Profit and XP Calculator',
+            description: 'Rank minions by collection interval, storage, budget, coins per day, experience, and setup cost.',
+            keywords: ['minion calculator', 'best skyblock minion', 'minion profit', 'minion experience']
+        },
+        {
             url: '/lowSupply',
             priority: 0.8,
             changefreq: 'hourly' as const,


### PR DESCRIPTION
Automated patch from task `task_hkplvwvezu3cs7hlieha`.

Base branch: `main`
Base commit: `ea0c82c02d82a525e7997911195999c845d2723f`

Review: separate codex session recorded.

> WARNING: review uses a separate session of the same provider; it is not an independent-provider review

Tests:
- [x] `node_22` — sha256:a51578e7ce0554a1d56de1e2a4d7d0e28a34687a981ea76220b86dd00da29004
- [x] `npm_ci` — sha256:12e95fb95ce04b09dda55ff3b59dd2969926c75463d5fecbb707a9830721aabf
- [x] `production_build` — sha256:ec44600c8d00828d78c99e67cf35e4f123e7dde4c2469cc240abcd2bf2f9b861
- [x] `test_server_ready` — sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
- [x] `cypress_auction_cy_ts` — two head attempts, base replay for triage: head_exit=0 head_log_sha256=242e391451356fee27a9d71f998722e0d0716970c3520eeb6eb80b5a653055ab
- [x] `cypress_crafting-utils_cy_ts` — two head attempts, base replay for triage: head_exit=0 head_log_sha256=b7f441185bd57b266df730ed5139e121bfdd7c7f7f866c17e00cc4090f01d72a
- [x] `cypress_crafts_cy_ts` — two head attempts, base replay for triage: head_exit=0 head_log_sha256=ead13fd0cc4bd531e9621d99ee08d66cf406b72a26481d6337505ecc95ca0ab5
- [x] `cypress_filter_cy_ts` — two head attempts, base replay for triage: head_exit=0 head_log_sha256=0b5e039efc4620e13619ef4fc7d774e2bd075035b00958a303f70325a2b2f68b
- [x] `cypress_forge_cy_ts` — two head attempts, base replay for triage: head_exit=0 head_log_sha256=1240473b60dc7ae3ced4e4b1968b9c45c33e380d3d3c838a488d6d4f52ed3388
- [x] `cypress_generated-api-response-utils_cy_ts` — two head attempts, base replay for triage: head_exit=0 head_log_sha256=2951127293034afa68f28030e196bfdcf3779c8d5e4f4d30aff30cce9fbfc616
- [x] `cypress_item-redirect-utils_cy_ts` — two head attempts, base replay for triage: head_exit=0 head_log_sha256=12425bbb54931a0939274337ad23285796f092392737d2a30ae7a31deb8b6d69
- [x] `cypress_minions_cy_ts` — two head attempts, base replay for triage: head_exit=0 head_log_sha256=0326425d40b751213a05f49b6725b5a58f080567fbfced94e3052ad924d13829
- [x] `cypress_player_cy_ts` — two head attempts, base replay for triage: head_exit=0 head_log_sha256=99d6fe729148739c437cefbcb98bb66e8aa696d9782d4db1bbaa0564f8f6bd83
- [x] `cypress_search_cy_ts` — two head attempts, base replay for triage: head_exit=0 head_log_sha256=71848b75ff753c921a1160c035c8e6b7df7e8e8265bb7f5d3ff2f0191b443b8c
- [x] `authenticated_year_view_personas` — fixed synthetic test identities 1=free, 2=paid, 3=second paid control; free-versus-paid year-history only; premium-plus distinction not tested; credential-free test-only stub; network-none browser; no browser artifacts

---

Fixed the trusted gate failure with a Cypress-scoped TypeScript config: [cypress/tsconfig.json](/workspace/cypress/tsconfig.json:1) now compiles imported TSX using `react-jsx` instead of preserving JSX for webpack.

Validated:

- Exact failing `crafting-utils.cy.ts` command: passed
- `minions.cy.ts`: passed
- `npm run build`: passed
- Formatting and diff checks: passed
- No Cypress screenshots or other generated artifacts remain

Earlier minion fixes remain intact, and the unrelated `.env` change was untouched.

This PR cannot be merged or approved by the automation identity; human review is required.
