### PR TITLE
Fix #1537: Page breaking on year view

### DIFF
--- a/components/PriceGraph/AuctionHousePriceGraph/AuctionHousePriceGraph.tsx
+++ b/components/PriceGraph/AuctionHousePriceGraph/AuctionHousePriceGraph.tsx
@@ -8,8 +8,8 @@ import { getLoadingElement } from '../../../utils/LoadingUtils'
 import { AUCTION_GRAPH_LEGEND_SELECTION } from '../../../utils/SettingsUtils'
 import ActiveAuctions from '../../ActiveAuctions/ActiveAuctions'
 import ItemFilter, { getPrefillFilter } from '../../ItemFilter/ItemFilter'
-import { DateRange, DEFAULT_DATE_RANGE, ItemPriceRange } from '../../ItemPriceRange/ItemPriceRange'
-import { useValidRange } from '../../../hooks/useValidRange'
+import { DateRange, ItemPriceRange } from '../../ItemPriceRange/ItemPriceRange'
+import { getValidatedRange, useValidRange } from '../../../hooks/useValidRange'
 import Number from '../../Number/Number'
 import GoogleSignIn from '../../GoogleSignIn/GoogleSignIn'
 import RecentAuctions from '../../RecentAuctions/RecentAuctions'
@@ -29,6 +29,7 @@ import { useGetApiMayor } from '../../../api/_generated/skyApi'
 import type { PriceStatistics, CoflnetSkyMayorModelsModelElectionPeriod, AuctionPreview } from '../../../api/_generated/skyApi.schemas'
 import { hasHighEnoughPremium, PREMIUM_RANK } from '../../../utils/PremiumTypeUtils'
 import NitroAdSlot from '../../Ads/NitroAdSlot'
+import { getItemFilterFromUrl } from '../../../utils/Parser/URLParser'
 
 const HOUR_IN_MS = 60 * 60 * 1000
 
@@ -124,6 +125,7 @@ function AuctionHousePriceGraph(props: Props) {
 
     let fetchspanRef = useRef(fetchspan)
     fetchspanRef.current = fetchspan
+    let initialUrlFilter = useRef<string | null>(null)
 
     useEffect(() => {
         mounted = true
@@ -137,11 +139,13 @@ function AuctionHousePriceGraph(props: Props) {
 
     useEffect(() => {
         loadFilters().then(filters => {
-            fetchspan = DEFAULT_DATE_RANGE
-            setFetchspan(DEFAULT_DATE_RANGE)
+            const requestedRange = getValidatedRange(searchParams.get('range'))
+            const prefilledFilter = getPrefillFilter(filters)
+            initialUrlFilter.current = Object.keys(getItemFilterFromUrl()).length > 0 ? JSON.stringify(prefilledFilter) : null
+            setFetchspan(requestedRange)
             setFilters(filters)
             if (props.item) {
-                updateChart(fetchspan, getPrefillFilter(filters))
+                updateChart(requestedRange, prefilledFilter)
             }
         })
     }, [props.item.tag])
@@ -416,7 +420,10 @@ function AuctionHousePriceGraph(props: Props) {
 
     let onFilterChange = (filter: ItemFilter) => {
         setItemFilter({ ...filter })
-        setDefaultRangeSwitch(!defaultRangeSwitch)
+        if (initialUrlFilter.current !== JSON.stringify(filter)) {
+            initialUrlFilter.current = null
+            setDefaultRangeSwitch(value => !value)
+        }
         if (fetchspanRef.current !== DateRange.ACTIVE) {
             updateChart(fetchspanRef.current, filter)
         }

--- a/cypress/e2e/year-view.cy.ts
+++ b/cypress/e2e/year-view.cy.ts
@@ -1,0 +1,51 @@
+describe('Item year view', () => {
+    it('preserves year view while loading URL filters', () => {
+        cy.intercept('GET', '**/api/filter/options?itemTag=STING', {
+            delay: 800,
+            body: [
+                { name: 'ultimate_chimera', options: ['0', '5'], type: 48, longType: 'NUMERICAL, RANGE', description: null },
+                { name: 'looting', options: ['0', '5'], type: 48, longType: 'NUMERICAL, RANGE', description: null },
+                { name: 'divine_gift', options: ['0', '3'], type: 48, longType: 'NUMERICAL, RANGE', description: null }
+            ]
+        })
+        cy.intercept('GET', '**/api/item/price/STING/history/year*', request => {
+            const params = new URL(request.url).searchParams
+            if (params.has('ultimate_chimera')) {
+                request.alias = 'yearHistory'
+            }
+            request.reply({
+                averageSellTimeSeconds: 3600,
+                totalAuctionsSold: 2,
+                totalListed: 2,
+                totalSellers: 2,
+                totalBuyers: 2,
+                totalBids: 0,
+                totalCoinsTransferred: 1200000000,
+                totalAuctions: 2,
+                totalItemsSold: 2,
+                binCount: 2,
+                prices: [
+                    { min: 590000000, max: 610000000, avg: 600000000, volume: 1, time: '2026-08-01T00:00:00Z' },
+                    { min: 600000000, max: 600000000, avg: 600000000, volume: 1, time: '2026-08-02T00:00:00Z' }
+                ],
+                recentSamples: []
+            })
+        })
+
+        cy.visit('/item/STING?range=year&ultimate_chimera=4-4&looting=5-5&divine_gift=3-3', {
+            onBeforeLoad(window) {
+                window.sessionStorage.setItem('googleId', 'cypress-year-view-user')
+            }
+        })
+
+        cy.wait('@yearHistory').then(({ request }) => {
+            const params = new URL(request.url).searchParams
+            expect(params.get('ultimate_chimera')).to.equal('4-4')
+            expect(params.get('looting')).to.equal('5-5')
+            expect(params.get('divine_gift')).to.equal('3-3')
+        })
+        cy.location('search').should('include', 'range=year')
+        cy.contains('Statistics Summary').should('be.visible')
+        cy.contains('Avg Price:').should('be.visible')
+    })
+})


### PR DESCRIPTION
Automated patch for #1537 from task `task_ki75fg2ct2intsyesdsa`.

Base branch: `main`
Base commit: `ea0c82c02d82a525e7997911195999c845d2723f`

Review: separate codex session recorded.

> WARNING: review uses a separate session of the same provider; it is not an independent-provider review

Tests:
- [x] `node_22` — sha256:a51578e7ce0554a1d56de1e2a4d7d0e28a34687a981ea76220b86dd00da29004
- [x] `npm_ci` — sha256:a7eb95bd5c2d048749442cea1529ee160d91c38b7a3582bff1c51ed3ad4b4198
- [x] `production_build` — sha256:fb19cc3d1d96ce7c21ea2f29e53ac22f8d18f3303f731d480398d6ed5cc91a74
- [x] `test_server_ready` — sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
- [x] `regression_base_fail_patch_pass` — trusted-harness exact command, isolated checkout servers, and reviewed test overlays: overlay_derivation=frontend-bundle sibling_setup_exit=0 overlay_setup_exit=0 overlay_review_digest=sha256:db2828a83a237b86f785f18e4611dc5f77f60066fca6059d670ef2a9ca327431 overlay_receipt_sha256=6070ba15bf3f5936e8fb3279ab09ed10f1ee855d10bc5f2c52424ba51d35dc4c base_setup_exit=0 base_setup_log_sha256=4517f9bc623c4fa35c444a08856d8ef4374d8334f5e13d8d03b9a889c939e4f5 server_isolation_exit=0 base_exit=1 base_log_sha256=19bbadd09643e222a3623488af23447f8f3c86ceb016e0d4236b60bb3cf5bf57 patched_exit=0 patched_log_sha256=093d1e0c3d64074162c0eeeb6d73acc2c0a5f036e0bdd8bb7080185267b2888c
- [x] `cypress_auction_cy_ts` — two head attempts, base replay for triage: head_exit=0 head_log_sha256=5c8f6a111d03df656ffb605188c3f5dbf62590687d86ddd033d0b5aa868afb47
- [x] `cypress_crafting-utils_cy_ts_preexisting` — spec is red on the unpatched base commit and is not attributable to this change: two head attempts, base replay for triage: head_exit=1 head_log_sha256=4a7076abe693fb35002e1a849c819505c57263105ffa83524710cdbde6d5c086 base_exit=1 base_log_sha256=139c84fa0b8e8c178e4a2999da5370eaf2a0678f6fb8b810f63c1b35e0b07aef
- [x] `cypress_crafts_cy_ts` — two head attempts, base replay for triage: head_exit=0 head_log_sha256=2047e5da0524aefd8536fa884f857884dc8f815346104915bf34c7af42ce2d42
- [x] `cypress_filter_cy_ts` — two head attempts, base replay for triage: head_exit=0 head_log_sha256=0c69b31ea4b0fee257f3b9ae31e2dddf30248b0d6a280b803eaea2a5056d5077
- [x] `cypress_forge_cy_ts` — two head attempts, base replay for triage: head_exit=0 head_log_sha256=6f91ba1470d8f5d06542ef7d7f3014c135b9cbc7d7dc4df6c5fa360a71914b1f
- [x] `cypress_generated-api-response-utils_cy_ts` — two head attempts, base replay for triage: head_exit=0 head_log_sha256=783313e78502ccf633fc568dd5c354b3be6fdcef37a006cc12c339acd354f88a
- [x] `cypress_item-redirect-utils_cy_ts` — two head attempts, base replay for triage: head_exit=0 head_log_sha256=702fa6c52ee6675f26fa10e031498aea1d0948410bef4cac646ea6ff47867a26
- [x] `cypress_player_cy_ts` — two head attempts, base replay for triage: head_exit=0 head_log_sha256=96b64d0123eebad63bc0f303e835e32243c21937d64d3859ec75649eef5db66e
- [x] `cypress_search_cy_ts` — two head attempts, base replay for triage: head_exit=0 head_log_sha256=529bae1fc6b21acb2e0f66dcac2412bf387e26a4f5e94cc3e2f33e6635349631
- [x] `cypress_year-view_cy_ts` — two head attempts, base replay for triage: head_exit=0 head_log_sha256=979b30c53eac7b992b510297460e47a3f4326f095855294c152362a7138d1904
- [x] `authenticated_year_view_personas` — fixed synthetic test identities 1=free, 2=paid, 3=second paid control; free-versus-paid year-history only; premium-plus distinction not tested; credential-free test-only stub; network-none browser; no browser artifacts

---

Addressed the valid review finding.

- Initial URL-filter hydration now preserves `range=year`.
- Subsequent interactive filter changes retain the original default-range reset behavior.
- Recreated the required regression manifest.

Checks passed:

- `npm run build`
- `cypress/e2e/year-view.cy.ts`
- `git diff --check`

The unrelated existing `.env` modification remains untouched.

This PR cannot be merged or approved by the automation identity; human review is required.
