### PR TITLE
Fix #1543: having no time span break the bazaar chart

### DIFF
--- a/components/PriceGraph/BazaarPriceGraph/BazaarPriceGraph.tsx
+++ b/components/PriceGraph/BazaarPriceGraph/BazaarPriceGraph.tsx
@@ -255,8 +255,13 @@ function BazaarPriceGraph(props: Props) {
                     series: newChartOptions.series
                 })
 
+                let timestamps = chartOptions.xAxis[0].data
                 let midPercentage = (e.start + e.end) / 2 / 100
-                let midDate = new Date(+chartOptions.xAxis[0].data[Math.ceil(chartOptions.xAxis[0].data.length * midPercentage)])
+                let midIndex = Math.min(timestamps.length - 1, Math.ceil(timestamps.length * midPercentage))
+                let midDate = new Date(+timestamps[midIndex])
+                if (globalThis.Number.isNaN(midDate.getTime())) {
+                    return
+                }
                 setTimeout(() => {
                     document.dispatchEvent(new CustomEvent(CUSTOM_EVENTS.BAZAAR_SNAPSHOT_UPDATE, { detail: { timestamp: midDate } }))
                 }, 100)

--- a/cypress/e2e/bazaar-chart-range.cy.ts
+++ b/cypress/e2e/bazaar-chart-range.cy.ts
@@ -1,0 +1,60 @@
+describe('Bazaar chart range slider', () => {
+    const prices = Array.from({ length: 12 }, (_, index) => ({
+        timestamp: `2026-08-${String(index + 1).padStart(2, '0')}T00:00:00Z`,
+        buy: 100 + index,
+        sell: 90 + index,
+        minBuy: 99 + index,
+        maxBuy: 101 + index,
+        minSell: 89 + index,
+        maxSell: 91 + index,
+        buyVolume: 1000,
+        sellVolume: 1000,
+        buyMovingWeek: 100,
+        sellMovingWeek: 100
+    }))
+
+    it('keeps a valid chart when the range handles meet at the right edge', () => {
+        let invalidTimeError: Error | undefined
+        let rangeSnapshotRequests = 0
+        cy.on('uncaught:exception', error => {
+            if (error.message.includes('Invalid time value')) {
+                invalidTimeError = error
+            }
+            return false
+        })
+
+        cy.intercept('GET', '**/api/bazaar/ENCHANTED_CARROT/history/day', prices).as('history')
+        cy.intercept('GET', '**/api/mayor*', [])
+        cy.intercept('GET', '**/api/bazaar/ENCHANTED_CARROT/snapshot*', request => {
+            if (new URL(request.url).searchParams.get('timestamp') === '2026-08-12T00:00:00.000Z') {
+                rangeSnapshotRequests++
+            }
+            request.reply({
+                productId: 'ENCHANTED_CARROT',
+                timestamp: '2026-08-12T00:00:00Z',
+                buyOrders: [],
+                sellOrders: []
+            })
+        })
+
+        cy.visit('/item/ENCHANTED_CARROT?range=day')
+        cy.wait('@history')
+        cy.contains('h3', 'Bazaar data').parent().find('canvas').should('be.visible').then($canvas => {
+            const canvas = $canvas[0]
+            const bounds = canvas.getBoundingClientRect()
+            const sliderY = bounds.top + bounds.height - 20
+            const leftHandleX = bounds.left + bounds.width * 0.15
+            const rightHandleX = bounds.left + bounds.width * 0.89
+
+            cy.wrap($canvas)
+                .trigger('mousedown', { clientX: leftHandleX, clientY: sliderY, force: true })
+                .trigger('mousemove', { clientX: rightHandleX, clientY: sliderY, force: true })
+                .trigger('mouseup', { clientX: rightHandleX, clientY: sliderY, force: true })
+        })
+
+        cy.wait(1000)
+        cy.then(() => expect(invalidTimeError, 'range selection error').to.be.undefined)
+        cy.then(() => expect(rangeSnapshotRequests, 'valid snapshot request after handle overlap').to.equal(1))
+        cy.contains('h3', 'Bazaar data').parent().find('canvas').should('be.visible')
+    })
+})


### PR DESCRIPTION
Automated patch for #1543 from task `task_74bgi7wskoo4heiocrca`.

Base branch: `main`
Base commit: `e67dfe18c0721e95ed794c73b03c2b889e433f63`

Review: separate codex session recorded.

> WARNING: review uses a separate session of the same provider; it is not an independent-provider review

Tests:
- [x] `node_26` — sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
- [x] `npm_ci` — sha256:a45fa951e7ea5888790c9c2fb712a711488e63179ba8422f7a2d7a19350968b8
- [x] `production_build` — sha256:34c9fea69dc1157185b4a5c52a8d86feb9cf3bd404fed7b314f2c7861ce4d062
- [x] `test_server_ready` — sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
- [x] `regression_base_fail_patch_pass` — trusted-harness exact command, isolated checkout servers, and reviewed test overlays: overlay_derivation=frontend-bundle sibling_setup_exit=0 overlay_setup_exit=0 overlay_review_digest=sha256:024d459257387edb627979bcfe44c24f20bcae19225b2bca5b2b91e055c55a3c overlay_receipt_sha256=b3047afa381d0a4ddda5563bc1e8d8ea7484e2fb74cac676447f9fb398b2473d base_setup_exit=0 base_setup_log_sha256=841b26ced926d59e6b565a41ed4443a296ad680636d74b46071428b2db082965 server_isolation_exit=0 base_exit=1 base_log_sha256=282b955ee1e38abe4f71be2c8472c14d96ba529ae5f6ea5c69d5cd55fae92183 patched_exit=0 patched_log_sha256=3c9513ec9fce08d2171e14efb1a4b7acbecaac44c81c189c1065a0fbd3472828
- [x] `cypress_account-active-subscription_cy_ts` — two head attempts, base replay for triage: head_exit=0 head_log_sha256=c2ff88ea1aa8c65d484be4ecafab5f206cfe89b32f5fb1d03b1d3e1c2eb9b130
- [x] `cypress_auction_cy_ts` — two head attempts, base replay for triage: head_exit=0 head_log_sha256=ef49b7eb696fc68d44ec4d7c63f1d10e8560444e245c2df7a69c7580e2cdd375
- [x] `cypress_bazaar-chart-range_cy_ts` — two head attempts, base replay for triage: head_exit=0 head_log_sha256=cbe507bc1f302e093968ec59e5bd1a139b155a6af84f23f809e72e4228937ded
- [x] `cypress_crafting-utils_cy_ts` — two head attempts, base replay for triage: head_exit=0 head_log_sha256=59c731a6c9d276cffb4de0ac8384ba58c1f17d0b83e25e3baa5a1b0088652b51
- [x] `cypress_crafts_cy_ts` — two head attempts, base replay for triage: head_exit=0 head_log_sha256=abe2b55afd94b65dc6562bc97b8a3cee8eb1ae0515037e2b311476a5fab7e0ec
- [x] `cypress_filter_cy_ts` — two head attempts, base replay for triage: head_exit=0 head_log_sha256=af07c704a3c9a4f87f8677af27e7fd0d57204583d2092c50bbd25788df10bd09
- [x] `cypress_forge_cy_ts` — two head attempts, base replay for triage: head_exit=0 head_log_sha256=68ea283fb81e871bf70d2868718c6614d18e890c6915ffc2f52cd79986b2c640
- [x] `cypress_generated-api-response-utils_cy_ts` — two head attempts, base replay for triage: head_exit=0 head_log_sha256=5c427d289396a4a63e19e875cd405d29319be025cb500d4b3c9706545f2cc79a
- [x] `cypress_item-redirect-utils_cy_ts` — two head attempts, base replay for triage: head_exit=0 head_log_sha256=339b0f9061ddc1fa4e86d824fb8b800884ee90fc8e6f5aa06e4c07edfcc1c524
- [x] `cypress_node-toolchain_cy_ts` — two head attempts, base replay for triage: head_exit=0 head_log_sha256=f2627e8a33f0ef01473b933972b75d0dab4536a064659a0b37a2aa77ccf9f8d6
- [x] `cypress_player_cy_ts` — two head attempts, base replay for triage: head_exit=0 head_log_sha256=b72c4b6b095b58e6c5850d0f597a3c5fbd6308bc525ac31e3f66b6260a695dca
- [x] `cypress_search_cy_ts` — two head attempts, base replay for triage: head_exit=0 head_log_sha256=e112d849d3ba809baaffd1e46d72b1cb0e7424f675b9eb789e4144235f793f00
- [x] `cypress_year-view_cy_ts` — two head attempts, base replay for triage: head_exit=0 head_log_sha256=7d205a3ea268f4d26f4280022fc05a0b6960a00e8e8160d1f4277e0d0d9ed56c
- [x] `authenticated_year_view_personas` — fixed synthetic test identities 1=free, 2=paid, 3=second paid control; free-versus-paid year-history only; premium-plus distinction not tested; credential-free test-only stub; network-none browser; no browser artifacts

---

Reviewer finding resolved through host confirmation:

- Exact 83-byte manifest is retained at `control/primary/regression.json` and `control/review-1/regression.json`.
- Content declares only `cypress/e2e/bazaar-chart-range.cy.ts` with no config overlays.
- `/task/regression.json` was hidden by the managed-sandbox read policy, not missing.
- No repository manifest was added or tracked.

The source/spec patch remains unchanged and narrowly covers the reported Bazaar range-handle defect. It does not affect authentication, billing, player data, API boundaries, or deployment configuration.

This PR cannot be merged or approved by the automation identity; human review is required.
