### PR TITLE
Fix #1546: Clarify no start available when startedat is before year 2000

### DIFF
--- a/components/AuctionDetails/AuctionDetails.tsx
+++ b/components/AuctionDetails/AuctionDetails.tsx
@@ -37,6 +37,14 @@ interface Props {
     copyButtonValue: 'ingame' | 'web'
 }
 
+function formatAuctionStart(start: Date): string {
+    if (start.getUTCFullYear() < 2000) {
+        return 'No start available'
+    }
+
+    return start.toLocaleDateString() + ' ' + start.toLocaleTimeString()
+}
+
 function AuctionDetails(props: Props) {
     let [isNoAuctionFound, setIsNoAuctionFound] = useState(false)
     let [auctionDetails, setAuctionDetails] = useState<AuctionDetails | undefined>(props.auctionDetails ? parseAuctionDetails(props.auctionDetails) : undefined)
@@ -481,7 +489,7 @@ function AuctionDetails(props: Props) {
                         <span className={styles.label}>
                             <Badge bg={labelBadgeVariant}>Auction Created:</Badge>
                         </span>
-                        <span className="ellipse">{auctionDetails?.start.toLocaleDateString() + ' ' + auctionDetails.start.toLocaleTimeString()}</span>
+                        <span className="ellipse">{formatAuctionStart(auctionDetails.start)}</span>
                     </div>
                     {auctionDetails?.itemCreatedAt?.getTime() > 0 ? (
                         <div className={styles.detailRow}>

--- a/cypress/e2e/auction-start.cy.ts
+++ b/cypress/e2e/auction-start.cy.ts
@@ -1,0 +1,46 @@
+const auctionId = '73137bc47df84d31a9d8b010078ada0f'
+const recordedStart = '2022-02-26T06:59:28'
+
+function setTimezone(timezoneId: string) {
+    return Cypress.automation('remote:debugger:protocol', {
+        command: 'Emulation.setTimezoneOverride',
+        params: { timezoneId }
+    })
+}
+
+function visitAuctionWithStart(start: string) {
+    cy.intercept('GET', `/auction/${auctionId}`, request => {
+        request.continue(response => {
+            response.body = response.body.replaceAll(recordedStart, start)
+        })
+    })
+
+    cy.visit(`/auction/${auctionId}`)
+}
+
+function dismissConsentDialog() {
+    cy.get('body').then(body => {
+        const acceptButton = body.find('button').toArray().find(button => button.textContent?.trim() === 'Accept')
+        if (acceptButton) {
+            cy.wrap(acceptButton).click()
+        }
+    })
+}
+
+describe('Auction start date', () => {
+    it('applies the year-2000 cutoff in UTC', () => {
+        cy.then(() => setTimezone('Asia/Tokyo'))
+        visitAuctionWithStart('1999-12-31T23:30:00Z')
+
+        cy.contains('div', 'Auction Created:').should('be.visible').and('contain.text', 'No start available').and('not.contain.text', '1/1/1')
+        dismissConsentDialog()
+        cy.screenshot('auction-missing-start-wide', { capture: 'viewport' })
+        cy.viewport(375, 667)
+        cy.contains('div', 'Auction Created:').scrollIntoView()
+        cy.screenshot('auction-missing-start-mobile', { capture: 'viewport' })
+
+        cy.then(() => setTimezone('America/Los_Angeles'))
+        visitAuctionWithStart('2000-01-01T00:30:00Z')
+        cy.contains('div', 'Auction Created:').should('be.visible').and('not.contain.text', 'No start available').and('contain.text', '1999')
+    })
+})


### PR DESCRIPTION
## Summary

Auction details now show **“No start available”** when the start timestamp is before UTC year 2000. Valid start timestamps keep their existing local date/time display.

The focused Cypress regression checks both sides of the cutoff in Tokyo and Los Angeles, where local dates could otherwise select the wrong year. It reuses the existing auction fixture and captures the changed row at desktop and mobile widths with consent dismissed.

## Validation

**22/22 host checks passed.** Both GitHub CI checks (`container-ci / Test` and `cypress-run`) also passed. Host validation includes the production build, Cypress suite, authenticated persona checks, and the same focused regression failing on the pinned base and passing on the patch. The explicit TypeScript check also passed. Review ran in a separate Codex session using the same provider.

Fixes #1546. No live Next.js preview is available for this repository yet.

<details>
<summary>Task provenance and host validation receipts</summary>

Automated patch for #1546 from task `task_qjvcoi3z5k5k6zb5v76q`.

Base branch: `main`
Base commit: `8baefdc59cbb891ca1dac5faab59ae1ada345070`

Review: separate codex session recorded.

> WARNING: review uses a separate session of the same provider; it is not an independent-provider review

Tests:
- [x] `node_26` — sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
- [x] `npm_ci` — sha256:ed3bda1e34d5f50fc4c74f85ff96d0a161b917b4108f222d755c6892094aa5ba
- [x] `production_build` — sha256:2d6ab9036d73b216cc2919c918496d940f1675a17cb91ac64bab01d37a924d35
- [x] `test_server_ready` — sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
- [x] `regression_base_fail_patch_pass` — trusted-harness exact command, isolated checkout servers, and reviewed test overlays: overlay_derivation=frontend-bundle sibling_setup_exit=0 overlay_setup_exit=0 overlay_review_digest=sha256:b0210701f93b5b08d9456896ae48c77a95be7767c8f1d36de00f913ae8ec823a overlay_receipt_sha256=ae421972b41950c6e82a6c6ebf548bc91f1e1e3ad66eaeeb5b21981397a48afc base_setup_exit=0 base_setup_log_sha256=a86f6d163fd9007e7bd54935ef05a5d3e4d8553c2d88425f36247601288da196 server_isolation_exit=0 base_exit=1 base_log_sha256=b639559c3e1b2b2fb6dc782c5ee9f7beb42217f4f5c1c7162da8f26576342ede patched_exit=0 patched_log_sha256=e58b0ddc796b838fb535a7d7a3d01008fdd5f6d666f1431ada29ac5a8bc9f512
- [x] `cypress_account-active-subscription_cy_ts` — two head attempts, base replay for triage: head_exit=0 head_log_sha256=78abeb22051da7e98abeba0043d92e24061e3f326b2654028eee804fc18dc1e0
- [x] `cypress_auction-start_cy_ts` — two head attempts, base replay for triage: head_exit=0 head_log_sha256=f5389f1b1e7bdeb578e928eed1837b1d11d9b5e511c1e618230219fd5e4cb26a
- [x] `cypress_auction_cy_ts` — two head attempts, base replay for triage: head_exit=0 head_log_sha256=bfcde9ea99aabad80daac4396b9b7599ca20fd0ef04b0584db9e8b26a9875c34
- [x] `cypress_bazaar-snapshot-recovery_cy_ts` — two head attempts, base replay for triage: head_exit=0 head_log_sha256=c68776892edd18f899b296488e5d2104166b3afc4dc8f0516a70f2dc6b3b4049
- [x] `cypress_crafting-utils_cy_ts` — two head attempts, base replay for triage: head_exit=0 head_log_sha256=13442ff9ff582034733320533b0b174b5b69e15878fa9293719130eddaa85def
- [x] `cypress_crafts_cy_ts` — two head attempts, base replay for triage: head_exit=0 head_log_sha256=9da817ad43439b65885f0b8f24a0a655e0ab78d85c9ab2f023a3a9bead85a37c
- [x] `cypress_error-reporting_cy_ts` — two head attempts, base replay for triage: head_exit=0 head_log_sha256=07006eae810269a497f3c69af21b0d8aff2b13c6abffff147fb94f77f52a6484
- [x] `cypress_filter_cy_ts` — two head attempts, base replay for triage: head_exit=0 head_log_sha256=5404b1d5e8b871ec90180f65057221564237a80b76e39612b3608583b5bc4c40
- [x] `cypress_forge_cy_ts` — two head attempts, base replay for triage: head_exit=0 head_log_sha256=4a0515b799d46b06079c9c20bdbc421e3b228dee879eae31786d68f4f52a18a0
- [x] `cypress_generated-api-response-utils_cy_ts` — two head attempts, base replay for triage: head_exit=0 head_log_sha256=b90e9bce98901e52cc366daec8a887ece3585b4877d68a66b28e7f574541f86e
- [x] `cypress_item-redirect-utils_cy_ts` — two head attempts, base replay for triage: head_exit=0 head_log_sha256=83a2c9c9b0aa4a53bf6956bd391d749f6256e3242bb38c236f6dc3ba42a2f661
- [x] `cypress_node-toolchain_cy_ts` — two head attempts, base replay for triage: head_exit=0 head_log_sha256=14c3f470dd956bd1ab9cdaa78e20ad66fd6fdcce442ee0ed08e857d33f04bb31
- [x] `cypress_player_cy_ts` — two head attempts, base replay for triage: head_exit=0 head_log_sha256=3c18d50a18f56b26fc30b41940b0fce6a45b261dfebfe792d27781032351e5d0
- [x] `cypress_search_cy_ts` — two head attempts, base replay for triage: head_exit=0 head_log_sha256=c48219815c3f20fa42c779801ce8b0d5cc14e1eb435bf522b1dd2aa14bb652bb
- [x] `cypress_terms-acceptance_cy_ts` — two head attempts, base replay for triage: head_exit=0 head_log_sha256=6ceb8d24ba1f68074c69412896c3d6af56914b96b259dbc1989c5c2b00c84d1f
- [x] `cypress_year-view_cy_ts` — two head attempts, base replay for triage: head_exit=0 head_log_sha256=57a937a4ebb98d96000f4264201df1dc1a34e6821ca57fc97e91b55b881dbd7b
- [x] `authenticated_year_view_personas` — fixed synthetic test identities 1=free, 2=paid, 3=second paid control; free-versus-paid year-history only; premium-plus distinction not tested; credential-free test-only stub; network-none browser; no browser artifacts


</details>
